### PR TITLE
Add auto complete file.

### DIFF
--- a/ssc_autocomplete
+++ b/ssc_autocomplete
@@ -1,0 +1,40 @@
+# ssc completion                             -*- shell-script -*-
+
+_ssc()
+{
+    local cur words
+    _init_completion || return
+
+    local COMMANDS=(
+        "add"
+        "edit"
+        "help"
+        "list"
+        "remove"
+        "search"
+        "version"
+        )
+
+    local command i
+    for (( i=0; i < ${#words[@]}-1; i++ )); do
+        if [[ ${COMMANDS[@]} =~ ${words[i]} ]]; then
+            command=${words[i]}
+            break
+        fi
+    done
+    
+    case $prev in
+        edit|remove)
+            host_list=$(grep -oP 'Host\s+\K\S+' $HOME/.ssh/config)
+            COMPREPLY=( $( compgen -W "$host_list" -- "$cur" ) )
+                return 0
+            ;;
+    esac
+    
+    if [ "$command" = "" ]; then
+        COMPREPLY=( $( compgen -W '${COMMANDS[@]}' -- "$cur" ) )
+    fi
+
+    return 0
+} &&
+complete -F _ssc ssc


### PR DESCRIPTION
Hi!
I wrote auto complete file, but I can't add it to install.sh . install.sh affiliated to your repository  so hard.
If you want to add it to install.sh, copy ssc_autocoplete here:
`/usr/share/bash-completion/completions/ssc`